### PR TITLE
Added method signatures on PermissionsService to accept arrays of operation names

### DIFF
--- a/Rhino.Security.Tests/AuthorizationRepositoryFixture.cs
+++ b/Rhino.Security.Tests/AuthorizationRepositoryFixture.cs
@@ -592,7 +592,7 @@ namespace Rhino.Security.Tests
 
 			var parentOperation = authorizationRepository.GetOperationByName("/Account");
 			Assert.NotNull(parentOperation); // was created in setup
-			Assert.Equal(2, parentOperation.Children.Count); // /Edit, /Delete
+			Assert.Equal(3, parentOperation.Children.Count); // /Edit, /Disable, /Delete
 		}
 
 		[Fact]
@@ -773,7 +773,7 @@ namespace Rhino.Security.Tests
 
 			var parent = authorizationRepository.GetOperationByName("/Account");
 
-			Assert.Equal(0, parent.Children.Count);
+			Assert.Equal(1, parent.Children.Count); // /Disable
 		}
 
 		[Fact]

--- a/Rhino.Security.Tests/DatabaseFixture.cs
+++ b/Rhino.Security.Tests/DatabaseFixture.cs
@@ -99,7 +99,7 @@ namespace Rhino.Security.Tests
 			authorizationRepository.CreateUsersGroup("Administrators");
 			authorizationRepository.CreateEntitiesGroup("Important Accounts");
 			authorizationRepository.CreateOperation("/Account/Edit");
-
+			authorizationRepository.CreateOperation("/Account/Disable");
 
 			authorizationRepository.AssociateUserWith(user, "Administrators");
 			authorizationRepository.AssociateEntityWith(account, "Important Accounts");

--- a/Rhino.Security.Tests/PermissionsServiceFixture.cs
+++ b/Rhino.Security.Tests/PermissionsServiceFixture.cs
@@ -129,7 +129,7 @@ namespace Rhino.Security.Tests
         }
 
         [Fact]
-        public void CanGetPermissionsByUserAndOpernationName_WhenPermissionOnEverything()
+        public void CanGetPermissionsByUserAndOperationName_WhenPermissionOnEverything()
         {
             permissionsBuilderService
                 .Allow("/Account")
@@ -144,6 +144,42 @@ namespace Rhino.Security.Tests
         }        
 
         [Fact]
+        public void CanGetPermissionsByUserAndMultipleOperationNames_WhenPermissionOnEverything()
+        {
+            permissionsBuilderService
+                .Allow("/Account/Edit")
+                .For(user)
+                .OnEverything()
+                .DefaultLevel()
+                .Save();
+            permissionsBuilderService
+                .Allow("/Account/Disable")
+                .For(user)
+                .OnEverything()
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetGlobalPermissionsFor(user, new string[] { "/Account/Edit", "/Account/Disable" });
+            Assert.Equal(2, permissions.Length);
+        }
+
+        [Fact]
+        public void CanGetPermissionsByUserAndMultipleOperationNames_WhenPermissionOnASingleOperation()
+        {
+            permissionsBuilderService
+                .Allow("/Account/Edit")
+                .For(user)
+                .OnEverything()
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetGlobalPermissionsFor(user, new string[] { "/Account/Edit", "/Account/Disable" });
+            Assert.Equal(1, permissions.Length);
+        }
+
+        [Fact]
         public void CanGetPermissionByUserEntityAndOperation()
         {
             permissionsBuilderService
@@ -156,6 +192,42 @@ namespace Rhino.Security.Tests
 
             Permission[] permissions = permissionService.GetPermissionsFor(user, account, "/Account/Edit");
             Assert.Equal(1, permissions.Length);
+        }
+
+        [Fact]
+        public void CanGetPermissionByUserEntityAndMultipleOperations()
+        {
+            permissionsBuilderService
+                .Allow("/Account/Edit")
+                .For(user)
+                .On("Important Accounts")
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetPermissionsFor(user, account, new string[] { "/Account/Edit", "/Account/Disable" });
+            Assert.Equal(1, permissions.Length);
+        }
+
+        [Fact]
+        public void CanGetPermissionsByUserEntityAndMultipleOperations()
+        {
+            permissionsBuilderService
+                .Allow("/Account/Edit")
+                .For(user)
+                .On("Important Accounts")
+                .DefaultLevel()
+                .Save();
+            permissionsBuilderService
+                .Allow("/Account/Disable")
+                .For(user)
+                .On("Important Accounts")
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetPermissionsFor(user, account, new string[] { "/Account/Edit", "/Account/Disable" });
+            Assert.Equal(2, permissions.Length);
         }
 
         [Fact]
@@ -174,6 +246,42 @@ namespace Rhino.Security.Tests
         }
 
         [Fact]
+        public void CanGetPermissionByMultipleOperations()
+        {
+            permissionsBuilderService
+                .Allow("/Account/Edit")
+                .For(user)
+                .On(account)
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetPermissionsFor(new string[] { "/Account/Edit", "/Account/Disable" });
+            Assert.Equal(1, permissions.Length);
+        }
+
+        [Fact]
+        public void CanGetPermissionsByMultipleOperations()
+        {
+            permissionsBuilderService
+                .Allow("/Account/Edit")
+                .For(user)
+                .On(account)
+                .DefaultLevel()
+                .Save();
+            permissionsBuilderService
+                .Allow("/Account/Disable")
+                .For(user)
+                .On(account)
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetPermissionsFor(new string[] { "/Account/Edit", "/Account/Disable" });
+            Assert.Equal(2, permissions.Length);
+        }
+
+        [Fact]
         public void CanGetPermissionByOperation_WhenParentOperationWasGranted()
         {
             permissionsBuilderService
@@ -185,6 +293,21 @@ namespace Rhino.Security.Tests
             session.Flush();
 
             Permission[] permissions = permissionService.GetPermissionsFor("/Account/Edit");
+            Assert.Equal(1, permissions.Length);
+        }
+
+        [Fact]
+        public void CanGetPermissionByMultipleOperations_WhenParentOperationWasGranted()
+        {
+            permissionsBuilderService
+                .Allow("/Account")
+                .For(user)
+                .On(account)
+                .DefaultLevel()
+                .Save();
+            session.Flush();
+
+            Permission[] permissions = permissionService.GetPermissionsFor(new string[] { "/Account/Edit", "/Account/Disable" });
             Assert.Equal(1, permissions.Length);
         }
 

--- a/Rhino.Security/Impl/Util/Strings.cs
+++ b/Rhino.Security/Impl/Util/Strings.cs
@@ -51,7 +51,7 @@ namespace Rhino.Security.Impl.Util
         /// </remarks>
         public static string[] GetHierarchicalOperationNames(string[] operationNames)
         {
-            return operationNames.SelectMany(GetHierarchicalOperationNames).Distinct().ToArray();
+            return operationNames.SelectMany<string,string>(GetHierarchicalOperationNames).Distinct().ToArray();
         }
 
 		/// <summary>

--- a/Rhino.Security/Impl/Util/Strings.cs
+++ b/Rhino.Security/Impl/Util/Strings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Rhino.Security.Model;
 using Rhino.Security.Properties;
@@ -40,6 +41,18 @@ namespace Rhino.Security.Impl.Util
 			} while (operationName != "");
 			return names.ToArray();
 		}
+
+        /// <summary>
+        /// Gets the names of all the parent operations (including the current one)
+        /// </summary>
+        /// <param name="operationNames">Names of the operations.</param>
+        /// <remarks>
+        /// Assumes that there is a '/' in the string
+        /// </remarks>
+        public static string[] GetHierarchicalOperationNames(string[] operationNames)
+        {
+            return operationNames.SelectMany(GetHierarchicalOperationNames).Distinct().ToArray();
+        }
 
 		/// <summary>
 		/// Joins the names of all the specified entities.

--- a/Rhino.Security/Interfaces/IPermissionsService.cs
+++ b/Rhino.Security/Interfaces/IPermissionsService.cs
@@ -30,14 +30,29 @@ namespace Rhino.Security.Interfaces
 		/// <param name="user">The user.</param>
 		/// <param name="operationName">Name of the operation.</param>
 		/// <returns></returns>
-		Permission[] GetGlobalPermissionsFor(IUser user, string operationName) ;
+        Permission[] GetGlobalPermissionsFor(IUser user, string operationName);
+
+        /// <summary>
+        /// Gets the permissions for the specified operations
+        /// </summary>
+        /// <param name="user">The user.</param>
+        /// <param name="operationNames">Names of the operations.</param>
+        /// <returns></returns>
+        Permission[] GetGlobalPermissionsFor(IUser user, string[] operationNames);
 
 		/// <summary>
 		/// Gets all permissions for the specified operation
 		/// </summary>
 		/// <param name="operationName">Name of the operation.</param>
 		/// <returns></returns>
-		Permission[] GetPermissionsFor(string operationName) ;
+        Permission[] GetPermissionsFor(string operationName);
+
+        /// <summary>
+        /// Gets all permissions for the specified operations
+        /// </summary>
+        /// <param name="operationNames">Names of the operations.</param>
+        /// <returns></returns>
+        Permission[] GetPermissionsFor(string[] operationNames);
 
 		/// <summary>
 		/// Gets the permissions for the specified entity
@@ -47,7 +62,17 @@ namespace Rhino.Security.Interfaces
 		/// <param name="entity">The entity.</param>
 		/// <param name="operationName">Name of the operation.</param>
 		/// <returns></returns>
-		Permission[] GetPermissionsFor<TEntity>(IUser user, TEntity entity, string operationName) where TEntity : class;
+        Permission[] GetPermissionsFor<TEntity>(IUser user, TEntity entity, string operationName) where TEntity : class;
+
+        /// <summary>
+        /// Gets the permissions for the specified entity
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="user">The user.</param>
+        /// <param name="entity">The entity.</param>
+        /// <param name="operationNames">Names of the operations.</param>
+        /// <returns></returns>
+        Permission[] GetPermissionsFor<TEntity>(IUser user, TEntity entity, string[] operationNames) where TEntity : class;
 
 		/// <summary>
 		/// Gets the permissions for the specified entity


### PR DESCRIPTION
We had a scenario where we needed to check the permissions for multiple operations
