### PR TITLE
Fix for second level cache miss when IUser implementation have no Equals/GetHashCode overrides

### DIFF
--- a/Rhino.Security.Tests/User.cs
+++ b/Rhino.Security.Tests/User.cs
@@ -2,6 +2,8 @@ namespace Rhino.Security.Tests
 {
     public class User : IUser
     {
+        public static bool DisableEqualityOverrides = false;
+
         public virtual long Id { get; set; }
 
         public virtual string Name { get; set; }
@@ -15,24 +17,39 @@ namespace Rhino.Security.Tests
             get { return new SecurityInfo(Name, Id); }
         }
 
-    	public virtual bool Equals(User other)
-    	{
-    		if (ReferenceEquals(null, other)) return false;
-    		if (ReferenceEquals(this, other)) return true;
-    		return other.Id == Id;
-    	}
+        public virtual bool Equals(User other)
+        {
+            if (DisableEqualityOverrides)
+            {
+                return base.Equals(other);
+            }
 
-    	public override bool Equals(object obj)
-    	{
-    		if (ReferenceEquals(null, obj)) return false;
-    		if (ReferenceEquals(this, obj)) return true;
-    		if (obj.GetType() != typeof (User)) return false;
-    		return Equals((User) obj);
-    	}
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return other.Id == Id;
+        }
 
-    	public override int GetHashCode()
-    	{
-    		return Id.GetHashCode();
-    	}
+        public override bool Equals(object obj)
+        {
+            if (DisableEqualityOverrides)
+            {
+                return base.Equals(obj);
+            }
+
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != typeof(User)) return false;
+            return Equals((User)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            if (DisableEqualityOverrides)
+            {
+                return base.GetHashCode();
+            }
+
+            return Id.GetHashCode();
+        }
     }
 }

--- a/Rhino.Security.Windsor.nuspec
+++ b/Rhino.Security.Windsor.nuspec
@@ -16,4 +16,12 @@
 			<dependency id="CommonServiceLocator.WindsorAdapter" version="1.0" />
 		</dependencies>
 	</metadata>
+	<files>
+		<file src="..\..\build\Rhino.Security.Windsor.dll" target="lib\net35" />
+		<file src="..\..\build\Rhino.Security.Windsor.pdb" target="lib\net35" />
+		<file src="..\..\build\Rhino.Security.Windsor.xml" target="lib\net35" />
+		<file src="..\..\acknowledgements.txt" />
+		<file src="..\..\license.txt" />
+		<file src="..\..\Rhino.Security.Windsor\**\*.cs" target="src" />
+	</files>
 </package>

--- a/Rhino.Security.nuspec
+++ b/Rhino.Security.nuspec
@@ -15,4 +15,13 @@
 			<dependency id="CommonServiceLocator" version="1.0" />
 		</dependencies>
 	</metadata>
+	<files>
+		<file src="..\..\build\Rhino.Security.dll" target="lib\net35" />
+		<file src="..\..\build\Rhino.Security.pdb" target="lib\net35" />
+		<file src="..\..\build\Rhino.Security.xml" target="lib\net35" />
+		<file src="..\..\acknowledgements.txt" />
+		<file src="..\..\How to Use.txt" />
+		<file src="..\..\license.txt" />
+		<file src="..\..\Rhino.Security\**\*.cs" target="src" />
+	</files>
 </package>

--- a/Rhino.Security/Services/AuthorizationService.cs
+++ b/Rhino.Security/Services/AuthorizationService.cs
@@ -166,7 +166,7 @@ namespace Rhino.Security.Services
 				.CreateAlias("entityGroup.Entities", "entityKey", JoinType.LeftOuterJoin)
 				.SetProjection(Projections.Property("Allow"))
 				.Add(Restrictions.In("op.Name", operationNames))
-				.Add(Restrictions.Eq("User", user) 
+				.Add(Restrictions.Eq("User.id", user.SecurityInfo.Identifier)
 				|| Subqueries.PropertyIn("UsersGroup.Id", 
 										 SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
 				.Add(

--- a/Rhino.Security/Services/PermissionsService.cs
+++ b/Rhino.Security/Services/PermissionsService.cs
@@ -40,7 +40,7 @@ namespace Rhino.Security.Services
 		public Permission[] GetPermissionsFor(IUser user)
 		{
 			DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-				.Add(Expression.Eq("User", user)
+				.Add(Expression.Eq("User.id", user.SecurityInfo.Identifier)
 				     || Subqueries.PropertyIn("UsersGroup.Id",
 				                              SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())));
 
@@ -72,7 +72,7 @@ namespace Rhino.Security.Services
 
             string[] allOperationNames = Strings.GetHierarchicalOperationNames(operationNames);
             DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-                .Add(Expression.Eq("User", user)
+                .Add(Expression.Eq("User.id", user.SecurityInfo.Identifier)
                      || Subqueries.PropertyIn("UsersGroup.Id",
                                               SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
                 .Add(Expression.IsNull("EntitiesGroup"))
@@ -124,7 +124,7 @@ namespace Rhino.Security.Services
 			EntitiesGroup[] entitiesGroups = authorizationRepository.GetAssociatedEntitiesGroupsFor(entity);
 
 			DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-				.Add(Expression.Eq("User", user)
+				.Add(Expression.Eq("User.id", user.SecurityInfo.Identifier)
 				     || Subqueries.PropertyIn("UsersGroup.Id",
 				                              SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
 				.Add(Expression.Eq("EntitySecurityKey", key) || Expression.In("EntitiesGroup", entitiesGroups));
@@ -163,7 +163,7 @@ namespace Rhino.Security.Services
                 (Restrictions.Eq("EntitySecurityKey", key) || Restrictions.In("EntitiesGroup", entitiesGroups)) ||
                 (Restrictions.IsNull("EntitiesGroup") && Restrictions.IsNull("EntitySecurityKey"));
             DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-                .Add(Restrictions.Eq("User", user)
+                .Add(Restrictions.Eq("User.id", user.SecurityInfo.Identifier)
                      || Subqueries.PropertyIn("UsersGroup.Id",
                                               SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
                 .Add(onCriteria)


### PR DESCRIPTION
When IUser implementation does not override Equals/GetHashCode, Rhino Security queries (like from IAuthorizationService.IsAllowed) miss the second level cache and go to database each time.

I'm not sure whenever overriding Equals/GetHashCode is mandatory/best practice when working with second level cache,
but if Rhino Security would consequently use Restrictions.Eq("user.id", user.SecurityInfo.Identifier),
as now it sometimes use that and sometimes Restrictions.Eq("user", user),
it would use second level cache even without proper Equals/GetHashCode on IUser implementation.

Added test and fix.
